### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nothing yet.
 
 ### Security
-
 - Nothing yet.
 
 ---
+
+
+## [0.3.0] - 2026-08-05
+
+- Switched from JWT http-only bearer token to session cookies
+- 
 
 ## [0.2.0] - 2025-08-16
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 Each player selects a tribe — **Romans, Gauls, or Teutons** — and starts with a single village.
 
-A village contains 16 resource fields producing four resources:
+A village contains 18 resource fields producing four resources:
 
-* 🌾 Corn
+* 🌾 Crop
 * ⛓️ Iron
 * 🪵 Wood
 * 🧱 Clay
@@ -110,7 +110,7 @@ From the `vallorium/` directory:
 
 ```bash
 docker compose run --rm backend \
-  alembic revision --autogenerate -m "add tribe metadata"
+  alembic revision --autogenerate -m "describe the schema change"
 ```
 
 Review the generated migration file before applying it.
@@ -132,10 +132,12 @@ When working directly inside the backend environment:
 cd vallorium/backend
 ```
 
+Generate a migration:
+
 ```bash
 poetry run alembic revision \
   --autogenerate \
-  -m "add tribe metadata and advantages"
+  -m "describe the schema change"
 ```
 
 Apply all pending migrations:
@@ -263,24 +265,40 @@ Make sure all CI checks pass before merging the Pull Request.
 
 ## 3. Merge into `main`
 
-Once the release PR has been merged:
+Merge the release Pull Request **before creating the release tag**.
+
+After the Pull Request has been merged, refresh the remote repository state:
 
 ```bash
-git checkout main
-git pull origin main
+git fetch origin
 ```
 
-The local `main` branch should now contain the release commit.
+Verify the latest commit on `main`:
+
+```bash
+git log -1 --oneline origin/main
+```
+
+The release tag must point to this commit.
 
 ---
 
 ## 4. Create the Git tag
 
-Create a version tag from `main`:
+Create an annotated version tag directly from `origin/main`:
 
 ```bash
-git tag v0.5.0
+git tag -a v0.5.0 origin/main -m "Release v0.5.0"
 ```
+
+Verify that the tag and `origin/main` point to the same commit:
+
+```bash
+git rev-list -n 1 v0.5.0
+git rev-parse origin/main
+```
+
+Both commands should return the same commit hash.
 
 Push the tag to GitHub:
 
@@ -288,17 +306,13 @@ Push the tag to GitHub:
 git push origin v0.5.0
 ```
 
-You can verify the tag with:
-
-```bash
-git show v0.5.0 --no-patch --oneline
-```
+This approach avoids accidentally tagging the current local branch and does not require checking out `main`.
 
 ---
 
 ## 5. Generate GitHub Release Notes
 
-Vallorium uses the GitHub CLI to generate release notes automatically from the changes included in the release.
+Vallorium uses the GitHub CLI to generate release notes automatically from the Pull Requests and changes included between releases.
 
 Authenticate the GitHub CLI if necessary:
 
@@ -306,47 +320,73 @@ Authenticate the GitHub CLI if necessary:
 gh auth login
 ```
 
-Then create the GitHub release:
+Create the GitHub release and explicitly specify the previous release tag:
 
 ```bash
 gh release create v0.5.0 \
   --generate-notes \
-  --title "v0.5.0"
+  --notes-start-tag v0.4.0 \
+  --title "v0.5.0" \
+  --verify-tag
 ```
 
-For example, the `v0.4.0` release was created with:
+For the next release, update both versions accordingly.
+
+For example:
 
 ```bash
-gh release create v0.4.0 \
+gh release create v0.6.0 \
   --generate-notes \
-  --title "v0.4.0"
+  --notes-start-tag v0.5.0 \
+  --title "v0.6.0" \
+  --verify-tag
 ```
 
-The complete release workflow is therefore:
+GitHub-generated release notes summarize the merged Pull Requests, contributors, and full changelog between the two release tags.
+
+---
+
+## Complete Release Workflow
+
+After the `dev → main` Pull Request has been merged:
 
 ```bash
-# After the dev → main PR has been merged
+# Refresh the remote repository state
+git fetch origin
 
-git checkout main
-git pull origin main
+# Verify the release commit on main
+git log -1 --oneline origin/main
 
-git tag v0.5.0
+# Create the release tag directly on origin/main
+git tag -a v0.5.0 origin/main -m "Release v0.5.0"
+
+# Verify the tag points to the same commit as origin/main
+git rev-list -n 1 v0.5.0
+git rev-parse origin/main
+
+# Push the tag
 git push origin v0.5.0
 
+# Create the GitHub release
 gh release create v0.5.0 \
   --generate-notes \
-  --title "v0.5.0"
+  --notes-start-tag v0.4.0 \
+  --title "v0.5.0" \
+  --verify-tag
 ```
 
 > Do not create the release tag before the `dev → main` Pull Request has been merged.
-> The version tag should point to the release commit on `main`.
+>
+> Always create the release tag from `origin/main`, not from the current local branch.
+>
+> Before pushing the tag, verify that the tag and `origin/main` resolve to the same commit.
 
 ---
 
 # 🛠️ Technologies
 
 * **Backend:** FastAPI
-* **Frontend:** Vue 3
+* **Frontend:** React, Vite, TypeScript, MUI, PixiJS
 * **Database:** PostgreSQL
 * **Database migrations:** Alembic
 * **Infrastructure as Code:** Terraform
@@ -414,7 +454,12 @@ The infrastructure includes:
     │       │
     │       ├── domains/            # Domain-oriented application logic
     │       │   ├── auth/
+    │       │   ├── buildings/
+    │       │   ├── dashboards/
+    │       │   ├── map/
+    │       │   ├── resources/
     │       │   ├── tribes/
+    │       │   ├── users/
     │       │   └── villages/
     │       │
     │       ├── game/               # Shared game rules and mechanics

--- a/vallorium/frontend/src/app/router.tsx
+++ b/vallorium/frontend/src/app/router.tsx
@@ -1,7 +1,8 @@
-import { Box, CircularProgress } from "@mui/material";
 import { lazy, Suspense } from "react";
 import { Navigate, createBrowserRouter } from "react-router-dom";
 
+import { GameShell } from "@/components/layouts/game-shell";
+import { FullPageLoader } from "@/components/ui/full-page-loader";
 import { LoginPage } from "@/features/auth/pages/login-page";
 import { SignupPage } from "@/features/auth/pages/signup-page";
 import { HomePage } from "@/features/villages/pages/home-page";
@@ -13,34 +14,28 @@ const WorldMapPage = lazy(() =>
   })),
 );
 
-
 export const router = createBrowserRouter([
   { path: "/", element: <Navigate to="/app" replace /> },
   { path: "/login", element: <LoginPage /> },
   { path: "/signup", element: <SignupPage /> },
   {
-    path: "/app",
-    element: (
-      <ProtectedRoute>
-        <HomePage />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: "/app/map",
-    element: (
-      <ProtectedRoute>
-        <Suspense
-          fallback={
-            <Box sx={{ minHeight: "100vh", display: "grid", placeItems: "center" }}>
-              <CircularProgress />
-            </Box>
-          }
-        >
-          <WorldMapPage />
-        </Suspense>
-      </ProtectedRoute>
-    ),
+    element: <ProtectedRoute />,
+    children: [
+      {
+        element: <GameShell />,
+        children: [
+          { path: "/app", element: <HomePage /> },
+          {
+            path: "/app/map",
+            element: (
+              <Suspense fallback={<FullPageLoader />}>
+                <WorldMapPage />
+              </Suspense>
+            ),
+          },
+        ],
+      },
+    ],
   },
   { path: "*", element: <Navigate to="/app" replace /> },
 ]);

--- a/vallorium/frontend/src/components/layouts/game-shell.tsx
+++ b/vallorium/frontend/src/components/layouts/game-shell.tsx
@@ -22,12 +22,12 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import type { MouseEvent, PropsWithChildren, ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import { GameLogo } from "@/components/brand/game-logo";
-import { storage } from "@/lib/storage";
+import { useLogout } from "@/features/auth/hooks/use-logout";
 import { gameTokens } from "@/theme";
 
 type NavItem = {
@@ -44,15 +44,11 @@ const navItems: NavItem[] = [
   { label: "Statistics", icon: <AnalyticsRoundedIcon fontSize="small" />, path: null },
 ];
 
-export function GameShell({ children }: PropsWithChildren) {
+export function GameShell() {
   const navigate = useNavigate();
   const location = useLocation();
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-
-  function logout() {
-    storage.clearAccessToken();
-    navigate("/login", { replace: true });
-  }
+  const { signOut, isSigningOut } = useLogout();
 
   function openMobileMenu(event: MouseEvent<HTMLElement>) {
     setMenuAnchor(event.currentTarget);
@@ -149,7 +145,7 @@ export function GameShell({ children }: PropsWithChildren) {
                 <AccountCircleRoundedIcon />
               </Avatar>
               <Tooltip title="Sign out">
-                <IconButton onClick={logout} aria-label="Sign out">
+                <IconButton onClick={() => signOut()} disabled={isSigningOut} aria-label="Sign out">
                   <LogoutRoundedIcon fontSize="small" />
                 </IconButton>
               </Tooltip>
@@ -157,7 +153,7 @@ export function GameShell({ children }: PropsWithChildren) {
           </Toolbar>
         </Container>
       </AppBar>
-      {children}
+      <Outlet />
     </Box>
   );
 }

--- a/vallorium/frontend/src/components/ui/full-page-loader.tsx
+++ b/vallorium/frontend/src/components/ui/full-page-loader.tsx
@@ -1,0 +1,9 @@
+import { Box, CircularProgress } from "@mui/material";
+
+export function FullPageLoader() {
+  return (
+    <Box sx={{ minHeight: "100vh", display: "grid", placeItems: "center" }}>
+      <CircularProgress />
+    </Box>
+  );
+}

--- a/vallorium/frontend/src/features/auth/api/get-current-user.ts
+++ b/vallorium/frontend/src/features/auth/api/get-current-user.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+
+import type { AuthResponse, AuthUser } from "@/features/auth/types/auth";
+import { api } from "@/lib/api";
+
+export async function getCurrentUser(signal?: AbortSignal): Promise<AuthUser | null> {
+  try {
+    const { data } = await api.get<AuthResponse>("/auth/me", { signal });
+
+    return data.user;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      return null;
+    }
+
+    throw error;
+  }
+}

--- a/vallorium/frontend/src/features/auth/api/logout.ts
+++ b/vallorium/frontend/src/features/auth/api/logout.ts
@@ -1,0 +1,5 @@
+import { api } from "@/lib/api";
+
+export async function logout(): Promise<void> {
+  await api.post("/auth/logout");
+}

--- a/vallorium/frontend/src/features/auth/auth-query.ts
+++ b/vallorium/frontend/src/features/auth/auth-query.ts
@@ -1,0 +1,9 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import type { AuthUser } from "@/features/auth/types/auth";
+
+export const currentUserQueryKey = ["auth", "current-user"] as const;
+
+export function cacheCurrentUser(queryClient: QueryClient, user: AuthUser) {
+  queryClient.setQueryData(currentUserQueryKey, user);
+}

--- a/vallorium/frontend/src/features/auth/components/login-form.tsx
+++ b/vallorium/frontend/src/features/auth/components/login-form.tsx
@@ -4,29 +4,19 @@ import {
   Alert,
   Box,
   Button,
-  Checkbox,
   CircularProgress,
-  Divider,
-  FormControlLabel,
   InputAdornment,
   Stack,
   TextField,
   Typography,
 } from "@mui/material";
-import { Link as RouterLink, useNavigate } from "react-router-dom";
+import { Link as RouterLink } from "react-router-dom";
 
 import { useLoginForm } from "@/features/auth/hooks/use-login-form";
-import { storage } from "@/lib/storage";
 import { gameTokens } from "@/theme";
 
 export function LoginForm() {
-  const navigate = useNavigate();
   const { values, error, isSubmitting, handleSubmit, updateField } = useLoginForm();
-
-  function openPreview() {
-    storage.setAccessToken("development-preview");
-    navigate("/app");
-  }
 
   return (
     <Box component="form" onSubmit={handleSubmit} noValidate>
@@ -76,28 +66,9 @@ export function LoginForm() {
           }}
         />
 
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <FormControlLabel
-            control={<Checkbox size="small" defaultChecked />}
-            label={<Typography variant="body2">Keep me signed in</Typography>}
-          />
-          <Button size="small" variant="text" sx={{ px: 1 }}>
-            Forgot password?
-          </Button>
-        </Stack>
-
         <Button type="submit" variant="contained" size="large" disabled={isSubmitting}>
           {isSubmitting ? <CircularProgress size={23} color="inherit" /> : "Enter the realm"}
         </Button>
-
-        {import.meta.env.DEV ? (
-          <>
-            <Divider>or</Divider>
-            <Button type="button" variant="outlined" onClick={openPreview}>
-              Preview the village dashboard
-            </Button>
-          </>
-        ) : null}
 
         <Typography variant="body2" color="text.secondary" textAlign="center">
           New to Verdant Realms?{" "}

--- a/vallorium/frontend/src/features/auth/hooks/use-current-user.ts
+++ b/vallorium/frontend/src/features/auth/hooks/use-current-user.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getCurrentUser } from "@/features/auth/api/get-current-user";
+import { currentUserQueryKey } from "@/features/auth/auth-query";
+
+export function useCurrentUser() {
+  return useQuery({
+    queryKey: currentUserQueryKey,
+    queryFn: ({ signal }) => getCurrentUser(signal),
+    retry: false,
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+  });
+}

--- a/vallorium/frontend/src/features/auth/hooks/use-login-form.ts
+++ b/vallorium/frontend/src/features/auth/hooks/use-login-form.ts
@@ -1,72 +1,58 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import axios from "axios";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState, type FormEvent } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { login } from "@/features/auth/api/login";
+import { cacheCurrentUser } from "@/features/auth/auth-query";
 import type { LoginFormValues } from "@/features/auth/types/auth";
+import { getRequestErrorMessage } from "@/features/auth/utils/get-request-error-message";
 
 const INITIAL_VALUES: LoginFormValues = {
   email: "",
   password: "",
 };
 
-function getErrorMessage(error: unknown, fallback: string): string {
-  if (!axios.isAxiosError(error)) {
-    return fallback;
+interface LoginLocationState {
+  from?: {
+    pathname?: string;
+    search?: string;
+    hash?: string;
+  };
+}
+
+function getPostLoginPath(state: LoginLocationState | null): string {
+  const from = state?.from;
+
+  if (!from?.pathname?.startsWith("/") || from.pathname.startsWith("//")) {
+    return "/app";
   }
 
-  const detail = error.response?.data?.detail;
-
-  if (typeof detail === "string") {
-    return detail;
-  }
-
-  if (Array.isArray(detail)) {
-    return detail
-      .map((item) => {
-        if (
-          item &&
-          typeof item === "object" &&
-          "msg" in item &&
-          typeof item.msg === "string"
-        ) {
-          return item.msg;
-        }
-
-        return "Invalid value";
-      })
-      .join(", ");
-  }
-
-  return fallback;
+  return `${from.pathname}${from.search ?? ""}${from.hash ?? ""}`;
 }
 
 export function useLoginForm() {
   const navigate = useNavigate();
-
+  const location = useLocation();
+  const queryClient = useQueryClient();
   const [values, setValues] = useState<LoginFormValues>(INITIAL_VALUES);
 
-  const [error, setError] = useState<string | null>(null);
-
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  async function handleSubmit(event: React.FormEvent) {
-    event.preventDefault();
-
-    setError(null);
-    setIsSubmitting(true);
-
-    try {
-      await login(values);
-
-      navigate("/app", {
+  const loginMutation = useMutation({
+    mutationFn: (formValues: LoginFormValues) =>
+      login({
+        email: formValues.email.trim(),
+        password: formValues.password,
+      }),
+    onSuccess: ({ user }) => {
+      cacheCurrentUser(queryClient, user);
+      navigate(getPostLoginPath(location.state as LoginLocationState | null), {
         replace: true,
       });
-    } catch (error) {
-      setError(getErrorMessage(error, "Unable to sign in."));
-    } finally {
-      setIsSubmitting(false);
-    }
+    },
+  });
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    loginMutation.mutate(values);
   }
 
   function updateField<K extends keyof LoginFormValues>(
@@ -77,12 +63,18 @@ export function useLoginForm() {
       ...current,
       [field]: value,
     }));
+
+    if (loginMutation.isError) {
+      loginMutation.reset();
+    }
   }
 
   return {
     values,
-    error,
-    isSubmitting,
+    error: loginMutation.error
+      ? getRequestErrorMessage(loginMutation.error, "Unable to sign in.")
+      : null,
+    isSubmitting: loginMutation.isPending,
     handleSubmit,
     updateField,
   };

--- a/vallorium/frontend/src/features/auth/hooks/use-logout.ts
+++ b/vallorium/frontend/src/features/auth/hooks/use-logout.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+
+import { logout } from "@/features/auth/api/logout";
+
+export function useLogout() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      // Remove all cached user-scoped server data before another user can sign in.
+      queryClient.clear();
+      navigate("/login", { replace: true });
+    },
+  });
+
+  return {
+    signOut: mutation.mutate,
+    isSigningOut: mutation.isPending,
+    signOutError: mutation.error,
+    resetSignOut: mutation.reset,
+  };
+}

--- a/vallorium/frontend/src/features/auth/hooks/use-signup-form.ts
+++ b/vallorium/frontend/src/features/auth/hooks/use-signup-form.ts
@@ -1,10 +1,12 @@
-import axios from "axios";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { login } from "@/features/auth/api/login";
 import { register } from "@/features/auth/api/register";
+import { cacheCurrentUser } from "@/features/auth/auth-query";
 import type { RegisterFormValues } from "@/features/auth/types/auth";
+import { getRequestErrorMessage } from "@/features/auth/utils/get-request-error-message";
 
 const INITIAL_VALUES: RegisterFormValues = {
   email: "",
@@ -13,106 +15,80 @@ const INITIAL_VALUES: RegisterFormValues = {
   tribeId: null,
 };
 
-function getErrorMessage(error: unknown, fallback: string): string {
-  if (!axios.isAxiosError(error)) {
-    return fallback;
-  }
-
-  const detail = error.response?.data?.detail;
-
-  if (typeof detail === "string") {
-    return detail;
-  }
-
-  if (Array.isArray(detail)) {
-    return detail
-      .map((item) => {
-        if (
-          item &&
-          typeof item === "object" &&
-          "msg" in item &&
-          typeof item.msg === "string"
-        ) {
-          return item.msg;
-        }
-
-        return "Invalid value";
-      })
-      .join(", ");
-  }
-
-  return fallback;
+interface SignupRequest {
+  email: string;
+  password: string;
+  tribeId: number;
+  idempotencyKey: string;
 }
 
 export function useSignupForm() {
   const navigate = useNavigate();
-
+  const queryClient = useQueryClient();
   const [values, setValues] = useState<RegisterFormValues>(INITIAL_VALUES);
-  const [error, setError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
   const idempotencyKey = useRef(crypto.randomUUID());
 
+  const signupMutation = useMutation({
+    mutationFn: async ({
+      email,
+      password,
+      tribeId,
+      idempotencyKey: requestIdempotencyKey,
+    }: SignupRequest) => {
+      await register(
+        { email, password, tribeId },
+        requestIdempotencyKey,
+      );
+
+      return login({ email, password });
+    },
+    onSuccess: ({ user }) => {
+      cacheCurrentUser(queryClient, user);
+      navigate("/app", { replace: true });
+    },
+  });
+
   function validateAccountStep(): boolean {
-    setError(null);
+    setValidationError(null);
 
     if (!values.email.trim()) {
-      setError("Enter your email address.");
+      setValidationError("Enter your email address.");
       return false;
     }
 
     if (values.password.length < 8) {
-      setError("Use at least 8 characters for your password.");
+      setValidationError("Use at least 8 characters for your password.");
       return false;
     }
 
     if (values.password !== values.confirmPassword) {
-      setError("The passwords do not match.");
+      setValidationError("The passwords do not match.");
       return false;
     }
 
     return true;
   }
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setError(null);
+    setValidationError(null);
 
     if (!validateAccountStep()) {
       return;
     }
 
     if (values.tribeId === null) {
-      setError("Choose a tribe before continuing.");
+      setValidationError("Choose a tribe before continuing.");
       return;
     }
 
-    setIsSubmitting(true);
-
-    const email = values.email.trim();
-
-    try {
-      await register(
-        {
-          email,
-          password: values.password,
-          tribeId: values.tribeId,
-        },
-        idempotencyKey.current,
-      );
-
-      await login({
-        email,
-        password: values.password,
-      });
-
-      navigate("/app", { replace: true });
-    } catch (requestError) {
-      setError(
-        getErrorMessage(requestError, "Unable to create your account."),
-      );
-    } finally {
-      setIsSubmitting(false);
-    }
+    signupMutation.mutate({
+      email: values.email.trim(),
+      password: values.password,
+      tribeId: values.tribeId,
+      idempotencyKey: idempotencyKey.current,
+    });
   }
 
   function updateField<K extends keyof RegisterFormValues>(
@@ -124,13 +100,25 @@ export function useSignupForm() {
       [field]: value,
     }));
 
+    setValidationError(null);
     idempotencyKey.current = crypto.randomUUID();
+
+    if (signupMutation.isError) {
+      signupMutation.reset();
+    }
   }
 
   return {
     values,
-    error,
-    isSubmitting,
+    error:
+      validationError ??
+      (signupMutation.error
+        ? getRequestErrorMessage(
+            signupMutation.error,
+            "Unable to create your account.",
+          )
+        : null),
+    isSubmitting: signupMutation.isPending,
     validateAccountStep,
     handleSubmit,
     updateField,

--- a/vallorium/frontend/src/features/auth/utils/get-request-error-message.ts
+++ b/vallorium/frontend/src/features/auth/utils/get-request-error-message.ts
@@ -1,0 +1,32 @@
+import axios from "axios";
+
+export function getRequestErrorMessage(error: unknown, fallback: string): string {
+  if (!axios.isAxiosError(error)) {
+    return fallback;
+  }
+
+  const detail = error.response?.data?.detail;
+
+  if (typeof detail === "string") {
+    return detail;
+  }
+
+  if (Array.isArray(detail)) {
+    return detail
+      .map((item) => {
+        if (
+          item &&
+          typeof item === "object" &&
+          "msg" in item &&
+          typeof item.msg === "string"
+        ) {
+          return item.msg;
+        }
+
+        return "Invalid value";
+      })
+      .join(", ");
+  }
+
+  return fallback;
+}

--- a/vallorium/frontend/src/features/villages/pages/home-page.tsx
+++ b/vallorium/frontend/src/features/villages/pages/home-page.tsx
@@ -1,7 +1,6 @@
 import RefreshRoundedIcon from "@mui/icons-material/RefreshRounded";
 import { Alert, Box, Container, IconButton, Skeleton, Stack, Tooltip, Typography } from "@mui/material";
 
-import { GameShell } from "@/components/layouts/game-shell";
 import { ResourceBar } from "@/features/villages/components/resource-bar";
 import { VillageFieldMap } from "@/features/villages/components/village-field-map";
 import { VillageSidebar } from "@/features/villages/components/village-sidebar";
@@ -16,55 +15,53 @@ export function HomePage() {
   const village = villages[0];
 
   return (
-    <GameShell>
-      <Container maxWidth={false} sx={{ maxWidth: gameTokens.layout.contentMaxWidth, pt: { xs: 2, md: 3 } }}>
-        {query.isError ? (
-          <Alert severity="warning" sx={{ mb: 2 }}>
-            The API is unavailable, so the dashboard is showing preview data. Retry after starting the FastAPI server.
-          </Alert>
-        ) : null}
+    <Container maxWidth={false} sx={{ maxWidth: gameTokens.layout.contentMaxWidth, pt: { xs: 2, md: 3 } }}>
+      {query.isError ? (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          The API is unavailable, so the dashboard is showing preview data. Retry after starting the FastAPI server.
+        </Alert>
+      ) : null}
 
-        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
-          <Box>
-            {query.isLoading ? (
-              <>
-                <Skeleton width={180} height={38} />
-                <Skeleton width={125} />
-              </>
-            ) : (
-              <>
-                <Typography variant="h4">{village.name}</Typography>
-                <Typography color="text.secondary" sx={{ mt: 0.35 }}>
-                  Capital village · Roman Empire
-                </Typography>
-              </>
-            )}
-          </Box>
-          <Tooltip title="Refresh village data">
-            <IconButton onClick={() => query.refetch()} aria-label="Refresh village data">
-              <RefreshRoundedIcon />
-            </IconButton>
-          </Tooltip>
-        </Stack>
-
-        <ResourceBar village={village} />
-
-        <Box
-          sx={{
-            mt: 2,
-            display: "grid",
-            gridTemplateColumns: { xs: "1fr", lg: "220px minmax(0, 1fr) 310px" },
-            gap: 2,
-            alignItems: "start",
-          }}
-        >
-          <Box sx={{ display: { xs: "none", lg: "block" } }}>
-            <VillageSidebar village={village} />
-          </Box>
-          <VillageFieldMap />
-          <VillageStatusPanel village={village} />
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+        <Box>
+          {query.isLoading ? (
+            <>
+              <Skeleton width={180} height={38} />
+              <Skeleton width={125} />
+            </>
+          ) : (
+            <>
+              <Typography variant="h4">{village.name}</Typography>
+              <Typography color="text.secondary" sx={{ mt: 0.35 }}>
+                Capital village · Roman Empire
+              </Typography>
+            </>
+          )}
         </Box>
-      </Container>
-    </GameShell>
+        <Tooltip title="Refresh village data">
+          <IconButton onClick={() => query.refetch()} aria-label="Refresh village data">
+            <RefreshRoundedIcon />
+          </IconButton>
+        </Tooltip>
+      </Stack>
+
+      <ResourceBar village={village} />
+
+      <Box
+        sx={{
+          mt: 2,
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", lg: "220px minmax(0, 1fr) 310px" },
+          gap: 2,
+          alignItems: "start",
+        }}
+      >
+        <Box sx={{ display: { xs: "none", lg: "block" } }}>
+          <VillageSidebar village={village} />
+        </Box>
+        <VillageFieldMap />
+        <VillageStatusPanel village={village} />
+      </Box>
+    </Container>
   );
 }

--- a/vallorium/frontend/src/features/world-map/pages/world-map-page.tsx
+++ b/vallorium/frontend/src/features/world-map/pages/world-map-page.tsx
@@ -18,7 +18,6 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { GameShell } from "@/components/layouts/game-shell";
 import { GamePanel } from "@/components/ui/game-panel";
 import { MapLegend } from "@/features/world-map/components/map-legend";
 import {
@@ -63,123 +62,121 @@ export function WorldMapPage() {
   const displayedTile = hoveredTile ?? selectedTile;
 
   return (
-    <GameShell>
-      <Container
-        maxWidth={false}
-        sx={{ maxWidth: gameTokens.layout.contentMaxWidth, pt: { xs: 2, md: 3 } }}
+    <Container
+      maxWidth={false}
+      sx={{ maxWidth: gameTokens.layout.contentMaxWidth, pt: { xs: 2, md: 3 } }}
+    >
+      {query.isError ? (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          The map API is unavailable, so this page is rendering the supplied resource-layout data as a local 100×100 preview world.
+        </Alert>
+      ) : null}
+
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        alignItems={{ xs: "stretch", sm: "center" }}
+        justifyContent="space-between"
+        spacing={1.5}
+        sx={{ mb: 2 }}
       >
-        {query.isError ? (
-          <Alert severity="info" sx={{ mb: 2 }}>
-            The map API is unavailable, so this page is rendering the supplied resource-layout data as a local 100×100 preview world.
-          </Alert>
-        ) : null}
-
-        <Stack
-          direction={{ xs: "column", sm: "row" }}
-          alignItems={{ xs: "stretch", sm: "center" }}
-          justifyContent="space-between"
-          spacing={1.5}
-          sx={{ mb: 2 }}
-        >
-          <Box>
-            {query.isLoading && !query.isError ? (
-              <>
-                <Skeleton width={210} height={42} />
-                <Skeleton width={330} />
-              </>
-            ) : (
-              <>
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <MapRoundedIcon color="primary" />
-                  <Typography variant="h4">World map</Typography>
-                </Stack>
-                <Typography color="text.secondary" sx={{ mt: 0.35 }}>
-                  Explore tiles, inspect field layouts, and find your next settlement.
-                </Typography>
-              </>
-            )}
-          </Box>
-
-          <Stack direction="row" spacing={0.75} alignItems="center">
-            <Tooltip title="Zoom out">
-              <IconButton onClick={() => canvasRef.current?.zoomOut()} aria-label="Zoom out">
-                <ZoomOutRoundedIcon />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Zoom in">
-              <IconButton onClick={() => canvasRef.current?.zoomIn()} aria-label="Zoom in">
-                <ZoomInRoundedIcon />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Reset view">
-              <IconButton onClick={() => canvasRef.current?.resetView()} aria-label="Reset map view">
-                <CenterFocusStrongRoundedIcon />
-              </IconButton>
-            </Tooltip>
-            <Button
-              variant="outlined"
-              startIcon={<MyLocationRoundedIcon />}
-              onClick={() => {
-                if (playerTile) canvasRef.current?.centerOn(playerTile.x, playerTile.y);
-              }}
-              disabled={!playerTile}
-              sx={{ display: { xs: "none", sm: "inline-flex" } }}
-            >
-              My village
-            </Button>
-            <Tooltip title="Refresh map data">
-              <IconButton onClick={() => query.refetch()} aria-label="Refresh map data">
-                <RefreshRoundedIcon />
-              </IconButton>
-            </Tooltip>
-          </Stack>
-        </Stack>
-
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: { xs: "1fr", xl: "minmax(0, 1fr) 320px" },
-            gap: 2,
-            alignItems: "start",
-          }}
-        >
-          <GamePanel sx={{ p: { xs: 0.75, md: 1 }, overflow: "hidden" }}>
-            <WorldMapCanvas
-              ref={canvasRef}
-              tiles={mapData.tiles}
-              bounds={mapData.bounds}
-              selectedTileId={selectedTile?.id ?? null}
-              initialCenter={playerTile ? { x: playerTile.x, y: playerTile.y } : undefined}
-              onSelectTile={setSelectedTile}
-              onHoverTile={setHoveredTile}
-            />
-            <Stack
-              direction="row"
-              alignItems="center"
-              justifyContent="space-between"
-              sx={{ px: 1, pt: 1, pb: 0.25 }}
-            >
-              <Typography variant="caption" color="text.secondary">
-                Showing {mapData.tiles.length.toLocaleString()} tiles · World 1
+        <Box>
+          {query.isLoading && !query.isError ? (
+            <>
+              <Skeleton width={210} height={42} />
+              <Skeleton width={330} />
+            </>
+          ) : (
+            <>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <MapRoundedIcon color="primary" />
+                <Typography variant="h4">World map</Typography>
+              </Stack>
+              <Typography color="text.secondary" sx={{ mt: 0.35 }}>
+                Explore tiles, inspect field layouts, and find your next settlement.
               </Typography>
-              {displayedTile ? (
-                <Typography variant="caption" fontWeight={gameTokens.typography.weight.bold}>
-                  {displayedTile.x} | {displayedTile.y} · {displayedTile.resourceLayout}
-                </Typography>
-              ) : null}
-            </Stack>
-          </GamePanel>
-
-          <Stack spacing={2}>
-            <TileDetailsPanel
-              tile={selectedTile}
-              onCenter={(tile) => canvasRef.current?.centerOn(tile.x, tile.y)}
-              onOpenVillage={() => navigate("/app")}
-            />
-            <MapLegend />
-          </Stack>
+            </>
+          )}
         </Box>
-      </Container>
-    </GameShell>
+
+        <Stack direction="row" spacing={0.75} alignItems="center">
+          <Tooltip title="Zoom out">
+            <IconButton onClick={() => canvasRef.current?.zoomOut()} aria-label="Zoom out">
+              <ZoomOutRoundedIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Zoom in">
+            <IconButton onClick={() => canvasRef.current?.zoomIn()} aria-label="Zoom in">
+              <ZoomInRoundedIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Reset view">
+            <IconButton onClick={() => canvasRef.current?.resetView()} aria-label="Reset map view">
+              <CenterFocusStrongRoundedIcon />
+            </IconButton>
+          </Tooltip>
+          <Button
+            variant="outlined"
+            startIcon={<MyLocationRoundedIcon />}
+            onClick={() => {
+              if (playerTile) canvasRef.current?.centerOn(playerTile.x, playerTile.y);
+            }}
+            disabled={!playerTile}
+            sx={{ display: { xs: "none", sm: "inline-flex" } }}
+          >
+            My village
+          </Button>
+          <Tooltip title="Refresh map data">
+            <IconButton onClick={() => query.refetch()} aria-label="Refresh map data">
+              <RefreshRoundedIcon />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      </Stack>
+
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", xl: "minmax(0, 1fr) 320px" },
+          gap: 2,
+          alignItems: "start",
+        }}
+      >
+        <GamePanel sx={{ p: { xs: 0.75, md: 1 }, overflow: "hidden" }}>
+          <WorldMapCanvas
+            ref={canvasRef}
+            tiles={mapData.tiles}
+            bounds={mapData.bounds}
+            selectedTileId={selectedTile?.id ?? null}
+            initialCenter={playerTile ? { x: playerTile.x, y: playerTile.y } : undefined}
+            onSelectTile={setSelectedTile}
+            onHoverTile={setHoveredTile}
+          />
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ px: 1, pt: 1, pb: 0.25 }}
+          >
+            <Typography variant="caption" color="text.secondary">
+              Showing {mapData.tiles.length.toLocaleString()} tiles · World 1
+            </Typography>
+            {displayedTile ? (
+              <Typography variant="caption" fontWeight={gameTokens.typography.weight.bold}>
+                {displayedTile.x} | {displayedTile.y} · {displayedTile.resourceLayout}
+              </Typography>
+            ) : null}
+          </Stack>
+        </GamePanel>
+
+        <Stack spacing={2}>
+          <TileDetailsPanel
+            tile={selectedTile}
+            onCenter={(tile) => canvasRef.current?.centerOn(tile.x, tile.y)}
+            onOpenVillage={() => navigate("/app")}
+          />
+          <MapLegend />
+        </Stack>
+      </Box>
+    </Container>
   );
 }

--- a/vallorium/frontend/src/routes/protected-route.tsx
+++ b/vallorium/frontend/src/routes/protected-route.tsx
@@ -1,14 +1,39 @@
-import type { PropsWithChildren } from "react";
-import { Navigate, useLocation } from "react-router-dom";
-import { storage } from "@/lib/storage";
+import { Alert, Box, Button, Stack } from "@mui/material";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 
-export function ProtectedRoute({ children }: PropsWithChildren) {
+import { FullPageLoader } from "@/components/ui/full-page-loader";
+import { useCurrentUser } from "@/features/auth/hooks/use-current-user";
+
+export function ProtectedRoute() {
   const location = useLocation();
-  const token = storage.getAccessToken();
+  const currentUser = useCurrentUser();
 
-  if (!token) {
+  if (currentUser.isPending) {
+    return <FullPageLoader />;
+  }
+
+  if (currentUser.isError) {
+    return (
+      <Box sx={{ minHeight: "100vh", display: "grid", placeItems: "center", p: 3 }}>
+        <Stack spacing={2} sx={{ width: "100%", maxWidth: 480 }}>
+          <Alert severity="error">
+            We could not verify your session. Check your connection and try again.
+          </Alert>
+          <Button
+            variant="contained"
+            disabled={currentUser.isFetching}
+            onClick={() => void currentUser.refetch()}
+          >
+            Try again
+          </Button>
+        </Stack>
+      </Box>
+    );
+  }
+
+  if (!currentUser.data) {
     return <Navigate to="/login" replace state={{ from: location }} />;
   }
 
-  return <>{children}</>;
+  return <Outlet />;
 }


### PR DESCRIPTION
## Summary

Refactors the frontend authentication flow to align with the new session-based auth system and removes remaining JWT/localStorage assumptions.

## Changes

- Remove access-token storage and JWT-based route protection
- Add centralized current-user session query
- Restore authenticated user state through `/auth/me`
- Cache the authenticated user after login and signup
- Update logout to invalidate the server session
- Centralize authentication request error handling
- Remove the development fake-token preview flow
- Simplify protected app routing and avoid duplicated wrappers
- Add shared loading state for session restoration

## Why

The frontend was still checking for an access token in localStorage after the backend migrated from JWT authentication to server-side sessions. This caused successful logins to redirect to `/app` and immediately return to `/login`.

The frontend now treats the server session as the source of truth and keeps the authenticated user in the TanStack Query cache.